### PR TITLE
html rendering tests use regex instead of naive diff now

### DIFF
--- a/server/tests/test_pdf_generator.py
+++ b/server/tests/test_pdf_generator.py
@@ -12,12 +12,9 @@ def test_render_html(transcript_dict):
         "transcript": transcript_dict,
     }
 
-
     html = render_html(transcript_data)
 
-    transcript_block_regex = re.compile(
-        r'<p><strong>(\d+):(\d+)<\/strong> - (.+)<\/p>'
-    )
+    transcript_block_regex = re.compile(r"<p><strong>(\d+):(\d+)<\/strong> - (.+)<\/p>")
 
     groups = re.findall(transcript_block_regex, html)
     assert len(groups) == len(transcript_dict)
@@ -27,9 +24,9 @@ def test_render_html(transcript_dict):
         end = int(captured_text[1])
         text = captured_text[2]
 
-        assert start == transcript_dict[i]['start']
-        assert end == transcript_dict[i]['end']
-        assert text == transcript_dict[i]['text']
+        assert start == transcript_dict[i]["start"]
+        assert end == transcript_dict[i]["end"]
+        assert text == transcript_dict[i]["text"]
 
     transcript_data = {
         "settings": {
@@ -64,12 +61,11 @@ def test_render_html_missing_data():
     html = render_html(transcript_data)
     assert len(html) > 0
 
-    transcript_block_regex = re.compile(
-        r'<p><strong>(\d+):(\d+)<\/strong> - (.+)<\/p>'
-    )
+    transcript_block_regex = re.compile(r"<p><strong>(\d+):(\d+)<\/strong> - (.+)<\/p>")
 
     groups = re.findall(transcript_block_regex, html)
     assert len(groups) == 0
+
 
 def test_generate_pdf():
     html_data = """\

--- a/server/tests/test_pdf_generator.py
+++ b/server/tests/test_pdf_generator.py
@@ -12,29 +12,24 @@ def test_render_html(transcript_dict):
         "transcript": transcript_dict,
     }
 
-    expected_html = """\
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Document</title>
-  <style>
-    body {
-      margin: 20px;
-    }
-  </style>
-</head>
-<body>
-  <p><strong>2:7</strong> - Good morning, everyone.</p>
-  <p><strong>10:16</strong> - Today, we'll discuss the new project.</p>
-  <p><strong>20:26</strong> - First, let's go through the objectives.</p>
-</body>
-</html>\
-"""
-    result = render_html(transcript_data)
 
-    assert expected_html == result
+    html = render_html(transcript_data)
+
+    transcript_block_regex = re.compile(
+        r'<p><strong>(\d+):(\d+)<\/strong> - (.+)<\/p>'
+    )
+
+    groups = re.findall(transcript_block_regex, html)
+    assert len(groups) == len(transcript_dict)
+
+    for i, captured_text in enumerate(groups):
+        start = int(captured_text[0])
+        end = int(captured_text[1])
+        text = captured_text[2]
+
+        assert start == transcript_dict[i]['start']
+        assert end == transcript_dict[i]['end']
+        assert text == transcript_dict[i]['text']
 
     transcript_data = {
         "settings": {
@@ -65,27 +60,16 @@ def test_render_html_missing_data():
         },
         "transcript": [],
     }
-    expected_html = """\
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Document</title>
-  <style>
-    body {
-      margin: 20px;
-    }
-  </style>
-</head>
-<body>
-</body>
-</html>\
-"""
-    result = render_html(transcript_data)
 
-    assert expected_html == result
+    html = render_html(transcript_data)
+    assert len(html) > 0
 
+    transcript_block_regex = re.compile(
+        r'<p><strong>(\d+):(\d+)<\/strong> - (.+)<\/p>'
+    )
+
+    groups = re.findall(transcript_block_regex, html)
+    assert len(groups) == 0
 
 def test_generate_pdf():
     html_data = """\


### PR DESCRIPTION
HTML rendering tests use regex to check if transcript blocks are rendered correctly now.