### PR TITLE
Update name and fix tutorial positions

### DIFF
--- a/transcript-client/src/components/Header.tsx
+++ b/transcript-client/src/components/Header.tsx
@@ -40,7 +40,7 @@ function Header(){
                 <Logo as="button" onClick={refreshPage} width="40px" height="40px" fill='white' stroke='white' strokeWidth="10"/>
             </Link>
             <Link to="/upload">
-                <Box as="button" onClick={refreshPage} ml="10px" color={"white"} fontWeight="bold" fontSize="30px" >Captioning</Box>
+                <Box as="button" onClick={refreshPage} ml="10px" color={"white"} fontWeight="bold" fontSize="30px">Transcribro</Box>
             </Link>
             <Box width="100%" alignItems="center" justifyContent="end" display={{base: "none", md: "flex"}}>
                 <AboutModal />

--- a/transcript-client/src/components/tutorials/AboutModal.tsx
+++ b/transcript-client/src/components/tutorials/AboutModal.tsx
@@ -25,22 +25,22 @@ function AboutModal(){
                 <ModalOverlay />
                 <ModalContent bg = {bgColor}>
                     <Box height="10px" bg="#557E4A" borderTopRadius="15px"></Box>
-                    <ModalHeader borderBottom="none" color="#557E4A">About Captioning</ModalHeader>
+                    <ModalHeader borderBottom="none" color="#557E4A">About Transcribro</ModalHeader>
                     <ModalCloseButton mt="2" />
                     <ModalBody pl="6" pr="6" mt="10px" mb="30px">
                         <Text mb="4">
-                            Welcome to Captioning, the assistive tool to make audio based media accessible 
+                            Welcome to Transcribro, the assistive tool to make audio based media accessible 
                             to people that are deaf or hard of hearing. Upload a file of a podcast, interview, 
                             or any spoken audio and follow the steps to generate a downloadable transcript.
                         </Text>
                         <Text mb="4">
                             Start by dragging your audio file onto the file icon or clicking underneath to 
-                            select one from your computer. Once the transcript is generated you will be able to
+                            select one from your computer. Once the transcript is generated, you will be able to
                             adjust the visual settings to customize the text as you wish. And when you're done you
                             can save the full customized transcript.
                         </Text>
                         <Text mb="2">
-                            If you get stuck at any point, check out the tutorials in the bottom right corner 
+                            If you get stuck at any point, check out the tutorials from the help button in the header 
                             for some direction.
                         </Text>
                     </ModalBody>

--- a/transcript-client/src/pages/Upload.tsx
+++ b/transcript-client/src/pages/Upload.tsx
@@ -19,8 +19,8 @@ const uploadTutorials = {
     {
       position: {
         pos: "fixed",
-        top: { base: "130px", md: "100px" },
-        right: { md: "4" },
+        top: { base: "130px", md: "72%" },
+        right: { md: "39%" },
       },
       text: "Upload an audio file in a variety of formats (mp3, mp4, mpeg, mpga, mp4a, wav, webm). Once uploaded, select the transcript language from the dropdown menu and click 'Transcribe'.",
     },

--- a/transcript-client/src/utils/standardTutorials.ts
+++ b/transcript-client/src/utils/standardTutorials.ts
@@ -10,11 +10,11 @@ export const standardTutorials = {
       text: "Use the sidebar to adjust the font style and size of the transcript text, or adjust the spacing between lines and words."
     },
     {
-      position: {pos: "fixed", left: {md: "380"}, top: {base: "130px", md: "390"}},
+      position: {pos: "fixed", left: {md: "380"}, top: {base: "130px", md: "58%"}},
       text: "Select lines within the text display to bold, italicize, or underline them."
     },
     {
-      position: {pos: "fixed", left: {md: "380"}, top: {base: "130px", md: "550"}},
+      position: {pos: "fixed", left: {md: "380"}, top: {base: "130px", md: "70%"}},
       text: "Adjust the color of the whole text or select lines to highlight specific sections."
     },
     {


### PR DESCRIPTION
Switched all Captioning branding to Transcribro to match the domain and fixed tutorial positions to match the associated content.